### PR TITLE
fix(ci): no gh token in trivy action

### DIFF
--- a/actions/ci-action-trivy/action.yml
+++ b/actions/ci-action-trivy/action.yml
@@ -21,10 +21,6 @@ inputs:
     description: "Exit code when issues found (0 to not fail)"
     required: false
     default: "0"
-  github_token:
-    description: "GitHub token for PR comments"
-    required: false
-    default: ${{ github.token }}
 
 runs:
   using: "composite"
@@ -124,7 +120,6 @@ runs:
       with:
         header: trivy-scan-${{ inputs.image_name || inputs.image_ref }}
         path: trivy-comment-${{ steps.suffix.outputs.value }}.md
-        GITHUB_TOKEN: ${{ inputs.github_token }}
 
     - name: Check for failures
       if: inputs.exit_code != '0'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `github_token` input and its usage in `action.yml` for Trivy action.
> 
>   - **Inputs**:
>     - Remove `github_token` input from `action.yml`.
>   - **Steps**:
>     - Remove `GITHUB_TOKEN` usage in `Post PR comment` step in `action.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2F.github&utm_source=github&utm_medium=referral)<sup> for e2a4da3e4dd4e5161575e3e181bee0e104c200f9. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified continuous integration configuration by removing unnecessary token parameter from action setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->